### PR TITLE
fix(ios): fallback to ggml Metal GPU when ANE is unavailable

### DIFF
--- a/MiniCPM-V-demo/Sources/Home/ViewController/MBHomeViewController+LoadModel.swift
+++ b/MiniCPM-V-demo/Sources/Home/ViewController/MBHomeViewController+LoadModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 extension MBHomeViewController {
-    
+
     /// 尝试重新加载多模态模型
     func checkMultiModelLoadStatusAndLoadIt() {
     
@@ -79,11 +79,22 @@ extension MBHomeViewController {
                     _ = await self.mtmdWrapperExample?.addImageInBackground(whiteImagePath)
                 } else if selectedModelType == .V46MultiModel {
                     let coremlPath = MiniCPMV46CoreMLBootstrap.resolvedCoreMLPathInDocuments()
-                    await self.mtmdWrapperExample?.initialize(
-                        modelPath: modelURL.path,
-                        mmprojPath: mmprojURL.path,
-                        coremlPath: coremlPath
-                    )
+                    if let coremlPath = coremlPath {
+                        await self.mtmdWrapperExample?.initialize(
+                            modelPath: modelURL.path,
+                            mmprojPath: mmprojURL.path,
+                            coremlPath: coremlPath
+                        )
+                    }
+                    // CoreML not available or loading failed → fallback to ggml Metal GPU
+                    if self.mtmdWrapperExample?.multiModelLoadingSuccess != true {
+                        print("[CoreML] loading failed, fallback to ggml Metal GPU")
+                        await self.mtmdWrapperExample?.initialize(
+                            modelPath: modelURL.path,
+                            mmprojPath: mmprojURL.path,
+                            coremlPath: nil
+                        )
+                    }
                 }
                 
                 // 更新模型加载状态为：加载成功，maybe 不需要，因为直接选择一张图提问时，也可能要重新 load model。


### PR DESCRIPTION
## Summary
- V46 model loading now tries CoreML first; if loading fails, automatically retries with ggml Metal GPU.
- No private APIs, no device blacklists — pure try-then-fallback logic.
- 1 file changed, +17 / -6 lines.

## Background
On some devices (e.g. iPhone 17 with iOS 26.x), CoreML fails to load or silently falls back to CPU, causing ViT inference to take ~47s. The ggml Metal GPU path handles the same inference in ~3s.

## Test Plan
- [ ] Device where CoreML works (e.g. iPhone 17 Pro): verify CoreML loads and is used
- [ ] Device where CoreML fails (e.g. iPhone 17 iOS 26.x): verify fallback to ggml Metal GPU
- [ ] Device without CoreML model downloaded: verify fallback works