### PR TITLE
feat(android): dynamic CPU dispatch for ggml-cpu

### DIFF
--- a/MiniCPM-V-demo-Android/app/build.gradle.kts
+++ b/MiniCPM-V-demo-Android/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 
                 arguments += "-DGGML_NATIVE=OFF"
                 arguments += "-DGGML_LLAMAFILE=ON"
-                arguments += "-DGGML_CPU_ARM_ARCH=armv8.6-a+dotprod+i8mm+fp16+bf16"
+                arguments += "-DGGML_CPU_ARM_ARCH=armv8.2-a+dotprod+fp16"
             }
         }
     }
@@ -115,4 +115,71 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic CPU dispatch: build an additional libggml-cpu.so optimised for
+// ARMv8.6-a (i8mm + bf16) and package it alongside the baseline build.
+// At runtime the Kotlin CpuFeatures helper detects hardware capabilities
+// and pre-loads the best variant before the rest of the native chain.
+// ---------------------------------------------------------------------------
+
+fun runCmd(vararg args: String) {
+    val proc = ProcessBuilder(*args).inheritIO().start()
+    val rc = proc.waitFor()
+    if (rc != 0) error("Command failed (rc=$rc): ${args.joinToString(" ")}")
+}
+
+val sdkRoot: String = System.getenv("ANDROID_HOME")
+    ?: file("../local.properties").takeIf { it.exists() }?.readLines()
+        ?.firstOrNull { it.startsWith("sdk.dir=") }?.substringAfter("=")
+    ?: error("Cannot locate Android SDK — set ANDROID_HOME or local.properties")
+
+tasks.register("buildGgmlCpu_v86") {
+    group = "native"
+    description = "Build libggml-cpu optimised for armv8.6-a+i8mm+bf16"
+
+    val destSo = file("src/main/jniLibs/arm64-v8a/libggml-cpu-v86.so")
+    outputs.file(destSo)
+
+    doLast {
+        val cmake = "$sdkRoot/cmake/3.22.1/bin/cmake"
+        val toolchain = "$sdkRoot/ndk/27.0.12077973/build/cmake/android.toolchain.cmake"
+        val bd = File(project.layout.buildDirectory.asFile.get(), "v86-cmake/arm64-v8a")
+        bd.mkdirs()
+
+        runCmd(
+            cmake,
+            "-DCMAKE_TOOLCHAIN_FILE=$toolchain",
+            "-DANDROID_ABI=arm64-v8a",
+            "-DANDROID_PLATFORM=android-24",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=ON",
+            "-DLLAMA_BUILD_COMMON=ON",
+            "-DLLAMA_OPENSSL=OFF",
+            "-DGGML_NATIVE=OFF",
+            "-DGGML_LLAMAFILE=ON",
+            "-DGGML_CPU_ARM_ARCH=armv8.6-a+dotprod+i8mm+fp16+bf16",
+            "-S", file("src/main/cpp").absolutePath,
+            "-B", bd.absolutePath,
+        )
+
+        runCmd(
+            cmake,
+            "--build", bd.absolutePath,
+            "--target", "ggml-cpu",
+            "-j", Runtime.getRuntime().availableProcessors().toString(),
+        )
+
+        val builtSo = fileTree(bd).matching { include("**/libggml-cpu.so") }.singleFile
+        destSo.parentFile.mkdirs()
+        builtSo.copyTo(destSo, overwrite = true)
+        logger.lifecycle("Copied v86 ggml-cpu -> ${destSo.absolutePath} (${destSo.length() / 1024}K)")
+    }
+}
+
+afterEvaluate {
+    listOf("Debug", "Release").forEach { buildType ->
+        tasks.findByName("merge${buildType}JniLibFolders")?.dependsOn("buildGgmlCpu_v86")
+    }
 }

--- a/MiniCPM-V-demo-Android/app/src/main/java/com/example/minicpm_v_demo/CpuFeatures.kt
+++ b/MiniCPM-V-demo-Android/app/src/main/java/com/example/minicpm_v_demo/CpuFeatures.kt
@@ -1,0 +1,46 @@
+package com.example.minicpm_v_demo
+
+import android.util.Log
+import java.io.File
+
+object CpuFeatures {
+    private const val TAG = "CpuFeatures"
+
+    private val features: Set<String> by lazy { readFeatures() }
+
+    val hasI8mm: Boolean get() = "i8mm" in features
+    val hasBf16: Boolean get() = "bf16" in features
+    val hasSve2: Boolean get() = "sve2" in features
+    val hasDotprod: Boolean get() = "asimddp" in features
+    val hasFp16: Boolean get() = "fphp" in features
+
+    /**
+     * Returns the best available ggml-cpu library name for the current CPU.
+     * The returned string can be passed to [System.load] after prepending
+     * the native library directory and "lib" prefix.
+     */
+    fun bestGgmlCpuVariant(): String? {
+        if (hasI8mm && hasBf16) return "v86"
+        return null
+    }
+
+    fun summary(): String = buildString {
+        append("CPU features: ${features.joinToString()}\n")
+        append("dotprod=$hasDotprod fp16=$hasFp16 i8mm=$hasI8mm bf16=$hasBf16 sve2=$hasSve2\n")
+        append("Selected ggml-cpu variant: ${bestGgmlCpuVariant() ?: "baseline"}")
+    }
+
+    private fun readFeatures(): Set<String> = try {
+        File("/proc/cpuinfo").readLines()
+            .filter { it.startsWith("Features") }
+            .firstOrNull()
+            ?.substringAfter(":")
+            ?.trim()
+            ?.split("\\s+".toRegex())
+            ?.toSet()
+            ?: emptySet<String>().also { Log.w(TAG, "No Features line in /proc/cpuinfo") }
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to read /proc/cpuinfo", e)
+        emptySet()
+    }
+}

--- a/MiniCPM-V-demo-Android/app/src/main/java/com/example/minicpm_v_demo/LlamaEngine.kt
+++ b/MiniCPM-V-demo-Android/app/src/main/java/com/example/minicpm_v_demo/LlamaEngine.kt
@@ -557,6 +557,19 @@ class LlamaEngine private constructor(
                 }
                 _state.value = LlamaState.Initializing
                 Log.i(TAG, "Loading native library...")
+                Log.i(TAG, CpuFeatures.summary())
+
+                val variant = CpuFeatures.bestGgmlCpuVariant()
+                if (variant != null) {
+                    try {
+                        Log.i(TAG, "Pre-loading optimised ggml-cpu ($variant)")
+                        System.loadLibrary("ggml-cpu-$variant")
+                        Log.i(TAG, "Optimised ggml-cpu ($variant) loaded successfully")
+                    } catch (e: UnsatisfiedLinkError) {
+                        Log.w(TAG, "Optimised ggml-cpu-$variant not available, using baseline", e)
+                    }
+                }
+
                 System.loadLibrary("minicpm_v_demo")
                 init(nativeLibDir)
                 _state.value = LlamaState.Initialized

--- a/MiniCPM-V-demo-Android/app/src/main/res/layout/dialog_image_slice.xml
+++ b/MiniCPM-V-demo-Android/app/src/main/res/layout/dialog_image_slice.xml
@@ -6,6 +6,7 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"


### PR DESCRIPTION
Build two variants of libggml-cpu.so in a single APK:
- baseline (armv8.2-a+dotprod+fp16) for broad compatibility
- optimized (armv8.6-a+i8mm+bf16) for flagship SoCs (2022+)

At runtime, CpuFeatures reads /proc/cpuinfo and pre-loads the optimized variant via SONAME preemption before the JNI dependency chain triggers. Tested on Snapdragon 7s Gen 2, Dimensity 9400, and Dimensity 700 — all from the same APK.

Also fix missing xmlns:tools in dialog_image_slice.xml.